### PR TITLE
development <= anthony/draft-2

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-googleAnalytics=""
+googleAnalytics="G-XZ5L2M9P80"

--- a/sanity/sanity.config.ts
+++ b/sanity/sanity.config.ts
@@ -4,6 +4,7 @@ import {visionTool} from '@sanity/vision'
 import {codeInput} from '@sanity/code-input'
 import {vercelDeployTool} from 'sanity-plugin-vercel-deploy'
 import {schemaTypes} from './schemaTypes'
+import {DocumentIcon} from '@sanity/icons'
 
 export default defineConfig({
   name: 'default',
@@ -12,7 +13,31 @@ export default defineConfig({
   projectId: '4vy6phvk',
   dataset: 'production',
 
-  plugins: [structureTool(), visionTool(), codeInput(), vercelDeployTool()],
+  plugins: [structureTool({
+    structure: (S) => {
+        return S.list()
+          .title("Content")
+          .items([
+            // Our singleton type has a list item with a custom child
+            S.listItem()
+              .title("Global content")
+              .id("globalContent")
+              .icon(DocumentIcon)
+              .child(
+                // Instead of rendering a list of documents, we render a single
+                // document, specifying the `documentId` manually to ensure
+                // that we're editing the single instance of the document
+                S.document()
+                  .schemaType("globalContent")
+                  .documentId("53c46b24-cf16-438f-9f9c-12537707112a")
+              ),
+              S.documentTypeListItem('post'),
+              S.documentTypeListItem('author'),
+              S.documentTypeListItem('page'),
+              S.documentTypeListItem('menu'),
+          ])
+      },
+  }), visionTool(), codeInput(), vercelDeployTool()],
 
   schema: {
     types: schemaTypes,

--- a/sanity/schemaTypes/blockContent.ts
+++ b/sanity/schemaTypes/blockContent.ts
@@ -54,6 +54,11 @@ export default defineType({
                 title: 'URL',
                 name: 'href',
                 type: 'url',
+                validation: (Rule: any) =>
+                  Rule.uri({
+                    allowRelative: true,
+                    scheme: ['http', 'https', 'mailto', 'tel'],
+                  }),
               },
             ],
           },

--- a/sanity/schemaTypes/globalContent.ts
+++ b/sanity/schemaTypes/globalContent.ts
@@ -1,0 +1,34 @@
+import {defineField, defineType} from 'sanity'
+import {DocumentTextIcon} from '@sanity/icons'
+
+export default defineType({
+  name: 'globalContent',
+  title: 'Homepage',
+  icon: DocumentTextIcon,
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Homepage Title',
+      type: 'string',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      title: 'Homepage Title alignment',
+      description: 'Choose to horizontally align the title',
+      name: 'titleAlignment',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'Left', value: 'left'},
+          {title: 'Center', value: 'center'},
+          {title: 'Right', value: 'right'},
+        ],
+      },
+      initialValue: 'left',
+      validation: (rule) => rule.required(),
+    }),
+  ],
+  preview: {
+  },
+})

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -6,6 +6,7 @@ import blockVideo from './blockVideo'
 import menu from './menu'
 import page from './page'
 import post from './post'
+import globalContent from './globalContent';
 import postTag from './postTag'
 
 export const schemaTypes = [
@@ -13,6 +14,7 @@ export const schemaTypes = [
   postTag,
   author,
   page,
+  globalContent,
   blockContent,
   blockImage,
   blockLink,

--- a/src/components/Author.astro
+++ b/src/components/Author.astro
@@ -12,7 +12,7 @@ interface Props {
 const { author, link = true, large = true } = Astro.props;
 
 const formattedTextSize = large
-  ? "text-md sm:text-2xl"
+  ? "text-md sm:text-xl"
   : "text-base lg:text-md leading-none";
 
 const formattedImageSize = large
@@ -34,14 +34,7 @@ const formattedImageSize = large
           mixBlend={false}
         />
       </div>
-      <span
-        class:list={[
-          "opacity-60",
-          "group-hover:opacity-100",
-          "group-hover:text-primary",
-          formattedTextSize,
-        ]}
-      >
+      <span class:list={["group-hover:text-primary", formattedTextSize]}>
         {author.urbitId}
       </span>
     </a>

--- a/src/components/PortableText.astro
+++ b/src/components/PortableText.astro
@@ -24,6 +24,7 @@ const components = {
     prose-headings:text-md
     prose-headings:font-normal
     hover:prose-a:no-underline
+    prose-blockquote:border-l-2
     prose-blockquote:font-normal
     prose-li:my-1.5"
 >

--- a/src/components/PortableText.astro
+++ b/src/components/PortableText.astro
@@ -24,7 +24,8 @@ const components = {
     prose-headings:text-md
     prose-headings:font-normal
     hover:prose-a:no-underline
-    prose-blockquote:font-normal"
+    prose-blockquote:font-normal
+    prose-li:my-1.5"
 >
   <PortableTextInternal value={portableText} components={components} />
 </div>

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -1,14 +1,20 @@
 ---
-import { getHomePosts } from "../utils/api";
+import { getHomePosts, getGlobalContent } from "../utils/api";
 
 import { type paginatedPageObj } from "../utils/types";
 
 import GlobalLayout from "../layouts/GlobalLayout.astro";
 import NewsletterSignup from "../components/NewsletterSignup.astro";
 import ExcerptList from "../components/ExcerptList.astro";
+import PageTitle from "@components/PageTitle.astro";
 
 interface Props {
   page: paginatedPageObj;
+}
+
+interface GlobalContent {
+  title: string;
+  titleAlignment: string;
 }
 
 export async function getStaticPaths({ paginate }: any) {
@@ -16,14 +22,17 @@ export async function getStaticPaths({ paginate }: any) {
   return paginate(posts, { pageSize: Number(import.meta.env.postsPerPage) });
 }
 
+const globalContent = (await getGlobalContent()) as GlobalContent;
+
 const { page } = Astro.props;
 ---
 
 <GlobalLayout>
-  <div class="mx-auto max-w-inner-sm space-y-8 pb-20 sm:pb-40">
-    <h1 class="text-xl sm:text-2xl">
-      A network-native social computer doesn&rsquo;t exist. Unless?
-    </h1>
+  <div class="mx-auto max-w-inner-sm space-y-16 pb-20 sm:pb-40">
+    <PageTitle
+      title={globalContent.title}
+      titleAlignment={globalContent.titleAlignment}
+    />
     <NewsletterSignup />
   </div>
 

--- a/src/pages/post/[slug].astro
+++ b/src/pages/post/[slug].astro
@@ -92,7 +92,7 @@ const {
           <h6 class="mb-6 text-md">Tagged:</h6>
           {tags.map((tag: tag) => (
             <a
-              class="mb-3 mr-3 inline-block rounded-2xl bg-mono-100 p-4 text-mono-600 transition-colors hover:bg-primary hover:text-white sm:text-md dark:bg-mono-800 dark:text-white"
+              class="mb-3 mr-3 inline-block rounded-xl bg-mono-100 px-4 py-2.5 text-mono-600 transition-colors hover:bg-primary hover:text-white sm:text-md dark:bg-mono-800 dark:text-white"
               href={`/tag/${tag.slug}`}
             >
               #{tag.slug}

--- a/src/pages/post/[slug].astro
+++ b/src/pages/post/[slug].astro
@@ -92,7 +92,7 @@ const {
           <h6 class="mb-6 text-md">Tagged:</h6>
           {tags.map((tag: tag) => (
             <a
-              class="mb-3 mr-3 inline-block rounded-xl bg-mono-100 px-4 py-2.5 text-mono-600 transition-colors hover:bg-primary hover:text-white sm:text-md dark:bg-mono-800 dark:text-white"
+              class="mb-3 mr-3 inline-block rounded-xl bg-mono-100 px-4 py-2.5 text-mono-600 transition-colors hover:bg-mono-200 sm:text-md dark:bg-mono-800 dark:text-white dark:hover:bg-mono-700"
               href={`/tag/${tag.slug}`}
             >
               #{tag.slug}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -12,6 +12,15 @@ const imageRefObj = `
 }
 `;
 
+export async function getGlobalContent() {
+  const query = `*[_type == "globalContent"][0] {
+    title,
+    titleAlignment
+  }`;
+  const data = await sanityClient.fetch(query);
+  return data;
+}
+
 // Homepage post excerpts with author information
 export async function getHomePosts() {
   const query = `*[_type == "post"] | order(_createdAt desc) {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -50,7 +50,7 @@ export default {
         "2xl": [
           "2rem", // 32px
           {
-            lineHeight: "2.5rem", // 40px
+            lineHeight: "3.125rem", // 50px
             letterSpacing: "0.00625rem", // 0.1px
           },
         ],


### PR DESCRIPTION
**Added**

- New "Global Content" type within Sanity that supports editing the homepage headline.
- Added support for structure within Sanity to make the UI inside the app easier to digest.

**Updated**

- Updated the `env` for production to include GA property.
- `blockContent` type inside Sanity now allows `mailto` and `tel` links.
- Reduced the text size and updated visual formatting of author information when used inside a post or post excerpt.
- `PortableText` updates:
    - Blockquote borders are smaller.
    - List item vertical margins were reduced.
- Homepage vertical spacing for primary headline and newsletter signup has been increased.
- Post tags now have less padding and a mono hover color.
- Updated tailwind config for `2xl` font size to have greater line height.