### PR TITLE
development <= add-tag-author-pages

### DIFF
--- a/src/components/Author.astro
+++ b/src/components/Author.astro
@@ -9,7 +9,7 @@ interface Props {
   large?: boolean;
 }
 
-const { author, large = true } = Astro.props;
+const { author, link = true, large = true } = Astro.props;
 
 const formattedTextSize = large
   ? "text-md"
@@ -22,18 +22,39 @@ const formattedImageSize = large
 const hasAvatar = author.image !== null;
 ---
 
-<div class:list={["flex items-center", { "space-x-4": hasAvatar }]}>
-  <div class={formattedImageSize}>
-    {
-      hasAvatar && (
-        <Picture
-          asset={author.image}
-          visualMaxWidth={32}
-          rounded
-          mixBlend={false}
-        />
-      )
-    }
-  </div>
-  <span class:list={[formattedTextSize]}>{author.urbitId}</span>
-</div>
+{
+  link ? (
+    <a
+      class:list={["group flex items-center", { "space-x-4": hasAvatar }]}
+      href={`/author/${author.slug}`}
+    >
+      <div class={formattedImageSize}>
+        {hasAvatar && (
+          <Picture
+            asset={author.image}
+            visualMaxWidth={32}
+            rounded
+            mixBlend={false}
+          />
+        )}
+      </div>
+      <span class:list={["group-hover:text-primary", formattedTextSize]}>
+        {author.urbitId}
+      </span>
+    </a>
+  ) : (
+    <div class:list={["flex items-center", { "space-x-4": hasAvatar }]}>
+      <div class={formattedImageSize}>
+        {hasAvatar && (
+          <Picture
+            asset={author.image}
+            visualMaxWidth={32}
+            rounded
+            mixBlend={false}
+          />
+        )}
+      </div>
+      <span class:list={[formattedTextSize]}>{author.urbitId}</span>
+    </div>
+  )
+}

--- a/src/components/PostExcerpt.astro
+++ b/src/components/PostExcerpt.astro
@@ -27,7 +27,7 @@ const { author, excerpt, featuredImage, slug, title } = Astro.props;
       <h2 class="text-xl sm:text-2xl">
         {title}
       </h2>
-      <Author author={author} />
+      <Author author={author} link={false} />
       <PortableText portableText={excerpt} />
     </div>
   </a>

--- a/src/components/RelatedPost.astro
+++ b/src/components/RelatedPost.astro
@@ -25,7 +25,7 @@ const { author, created, featuredImage, slug, title } = Astro.props;
     </div>
     <div class="space-y-4 pt-4">
       <h6 class="text-md lg:text-lg">{title}</h6>
-      <Author author={author} large={false} />
+      <Author author={author} large={false} link={false} />
       <time
         class="inline-block text-base text-mono-500 lg:text-md"
         datetime={created}

--- a/src/pages/author/[slug]/[...page].astro
+++ b/src/pages/author/[slug]/[...page].astro
@@ -1,0 +1,41 @@
+---
+import { getAuthorPage } from "../../../utils/api";
+
+import GlobalLayout from "../../../layouts/GlobalLayout.astro";
+import ExcerptList from "../../../components/ExcerptList.astro";
+
+interface Props {
+  page: any;
+  authorSlug: string;
+}
+
+export async function getStaticPaths({ paginate }: any) {
+  const authorObjects = await getAuthorPage();
+  const allCategories: any[] = [];
+  authorObjects.forEach((tabObject: { slug: any }) =>
+    allCategories.push(tabObject.slug)
+  );
+  return allCategories.flatMap(author => {
+    const filteredPosts = authorObjects.find(
+      (tagObject: { slug: any }) => tagObject.slug === author
+    );
+    return paginate(filteredPosts.posts, {
+      params: { slug: author },
+      props: { authorSlug: filteredPosts.slug },
+      pageSize: Number(import.meta.env.postsPerPage),
+    });
+  });
+}
+
+const { page, authorSlug } = Astro.props;
+---
+
+<GlobalLayout metaTitle=`Posts written by ${authorSlug}`>
+  <header class="mx-auto max-w-inner-sm pb-16">
+    <h1 class="text-2xl">
+      Posts written by:
+      <span class="text-primary">~{authorSlug}</span>
+    </h1>
+  </header>
+  <ExcerptList page={page} />
+</GlobalLayout>

--- a/src/pages/post/[slug].astro
+++ b/src/pages/post/[slug].astro
@@ -25,9 +25,14 @@ interface Props {
   metaDescription: string;
   metaTitle: string;
   relatedPosts: relatedPost[];
+  tags: tag[];
   title: string;
 }
 
+interface tag {
+  title: string;
+  slug: string;
+}
 interface relatedPost {
   title: string;
   slug: string;
@@ -48,6 +53,7 @@ const {
   featuredVideo,
   metaTitle,
   metaDescription,
+  tags,
   title,
   relatedPosts,
 } = Astro.props;
@@ -79,6 +85,22 @@ const {
     <div class="mx-auto max-w-inner-sm">
       <PortableText portableText={body} />
     </div>
+
+    {
+      tags && (
+        <div class="mx-auto max-w-inner-sm pt-20">
+          <h6 class="mb-6 text-md">Tagged:</h6>
+          {tags.map((tag: tag) => (
+            <a
+              class="mb-3 mr-3 inline-block rounded-xl bg-mono-100 px-4 py-2.5 text-mono-600 transition-colors hover:bg-mono-200 sm:text-md dark:bg-mono-800 dark:text-white dark:hover:bg-mono-700"
+              href={`/tag/${tag.slug}`}
+            >
+              #{tag.slug}
+            </a>
+          ))}
+        </div>
+      )
+    }
 
     {
       relatedPosts && relatedPosts.length > 0 && (

--- a/src/pages/tag/[slug]/[...page].astro
+++ b/src/pages/tag/[slug]/[...page].astro
@@ -1,0 +1,40 @@
+---
+import { getTagPage } from "../../../utils/api";
+
+import GlobalLayout from "../../../layouts/GlobalLayout.astro";
+import ExcerptList from "../../../components/ExcerptList.astro";
+
+interface Props {
+  page: any;
+  tagSlug: string;
+}
+
+export async function getStaticPaths({ paginate }: any) {
+  const tagObjects = await getTagPage();
+  const allCategories: any[] = [];
+  tagObjects.forEach((tabObject: { slug: any }) =>
+    allCategories.push(tabObject.slug)
+  );
+  return allCategories.flatMap(tag => {
+    const filteredPosts = tagObjects.find(
+      (tagObject: { slug: any }) => tagObject.slug === tag
+    );
+    return paginate(filteredPosts.posts, {
+      params: { slug: tag },
+      props: { tagSlug: filteredPosts.slug },
+      pageSize: Number(import.meta.env.postsPerPage),
+    });
+  });
+}
+
+const { page, tagSlug } = Astro.props;
+---
+
+<GlobalLayout metaTitle=`Posts tagged as ${tagSlug}`>
+  <header class="mx-auto max-w-inner-sm pb-16">
+    <h1 class="text-2xl">
+      Posts tagged as: <span class="text-primary">#{tagSlug}</span>
+    </h1>
+  </header>
+  <ExcerptList page={page} />
+</GlobalLayout>


### PR DESCRIPTION
> [!NOTE] 
> This is an optional future feature on the new site that was determined to be disabled for now. This PR is to ease the eventual addition of these features if decided. Please don't automatically merge this one (for now).

## What changed

**Added**

- Brand new post index pages for:
    - "Posts written by" author pages display all the posts from an individual author.
    - "Posts tagged by" tag pages display all the posts associated with an individual tag.

**Updated**

- Individual posts now include a display of all tags associated with the post
- `Author` component now includes the ability to be a link with the new `link` prop