### PR TITLE
astro: wider text column, other tweaks

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,12 +1,11 @@
 ---
 import { getHeaderNav } from "../utils/api";
 const links = await getHeaderNav();
-// const links = [];
 ---
 
 <header
   role="banner"
-  class="fixed left-0 top-0 z-10 flex w-full items-center justify-between bg-white px-4 leading-none md:bg-transparent md:px-8 md:py-6 dark:bg-blackish dark:md:bg-transparent"
+  class="fixed left-0 top-0 z-10 flex w-full items-center justify-between bg-white px-4 leading-none lg:bg-transparent lg:px-8 lg:py-6 dark:bg-blackish dark:md:bg-transparent"
 >
   <a class="inline-block w-12 p-4" href="/">
     <img id="t-block" src="/icon.svg" alt="Tlon logo" />

--- a/src/components/PortableText.astro
+++ b/src/components/PortableText.astro
@@ -26,6 +26,7 @@ const components = {
     prose-headings:pt-4
     prose-headings:text-md
     prose-headings:font-semibold
+    prose-a:font-normal
     hover:prose-a:no-underline
     prose-blockquote:border-l-2
     prose-blockquote:font-normal

--- a/src/components/PostExcerpt.astro
+++ b/src/components/PostExcerpt.astro
@@ -27,7 +27,7 @@ const { author, excerpt, featuredImage, slug, title } = Astro.props;
           <span class="whitespace-nowrap opacity-40">{author.label}</span>
         </h2>
       </header>
-      <div class="prose prose-lg prose-tlon leading-tight dark:prose-invert">
+      <div class="prose prose-lg prose-tlon dark:prose-invert leading-normal">
         <PortableTextInternal value={excerpt} />
       </div>
     </div>

--- a/src/layouts/GlobalLayout.astro
+++ b/src/layouts/GlobalLayout.astro
@@ -93,7 +93,7 @@ const analyticsId = import.meta.env.googleAnalytics;
       gtag("config", analyticsId);
     </script>
   </head>
-  <body class="pt-12 sm:pt-24">
+  <body class="pt-12 lg:pt-24">
     <Header />
     <main class="px-8 pt-16 md:pt-32">
       <slot />

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -33,7 +33,7 @@ const {
   metaTitle={metaTitle ? metaTitle : title}
 >
   <div>
-    <header class="max-w-inner-xs mx-auto">
+    <header class="max-w-inner-xs md:max-w-inner-sm mx-auto">
       <PageTitle title={title} titleAlignment={titleAlignment} />
     </header>
 
@@ -55,7 +55,7 @@ const {
 
     {
       body && (
-        <div class="max-w-inner-xs mx-auto pt-16">
+        <div class="max-w-inner-xs md:max-w-inner-sm mx-auto pt-16">
           <PortableText portableText={body} />
         </div>
       )

--- a/src/pages/post/[slug].astro
+++ b/src/pages/post/[slug].astro
@@ -57,7 +57,7 @@ const {
   metaTitle={metaTitle ? metaTitle : title}
 >
   <article>
-    <header class="max-w-inner-xs mx-auto space-y-4">
+    <header class="max-w-inner-xs md:max-w-inner-sm mx-auto space-y-4">
       <PageTitle title={title} />
       <Author author={author} />
     </header>
@@ -70,12 +70,12 @@ const {
         </div>
       ) : (
         <div class="mx-auto flex max-w-inner-lg items-center py-16">
-          <Picture asset={featuredImage} visualMaxWidth={550} />
+          <Picture asset={featuredImage} visualMaxWidth={750} />
         </div>
       )
     }
 
-    <div class="max-w-inner-xs mx-auto">
+    <div class="max-w-inner-xs md:max-w-inner-sm mx-auto">
       <PortableText portableText={body} />
     </div>
 
@@ -102,7 +102,7 @@ const {
       )
     }
 
-    <div class="max-w-inner-xs mx-auto pt-32">
+    <div class="max-w-inner-xs md:max-w-inner-sm mx-auto pt-32">
       <NewsletterSignup />
     </div>
   </article>


### PR DESCRIPTION
- Makes the post maximum line width much wider (from 550px to 750px); adjusts featured image max visual width to match
- Adjusts the header to accommodate our larger body width (solid background and tight padding up to 1024px, at which point the t-block and sign in links float in the margins)
- Makes links in post bodies uniform font-weight
- Loosens up the leading on excerpt listings (from 1.25 to 1.5)

Wider body copy:
![image](https://github.com/tloncorp/tlon.io/assets/748181/bc3190f9-db08-4e9f-a950-f31d164df67e)

Better line-height on excerpt listings:
![image](https://github.com/tloncorp/tlon.io/assets/748181/ce1bfca9-6f17-47ea-b00c-41caf9e501c9)