### PR TITLE
astro: generate anchor links from headings in portabletext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "astro": "^4.4.9",
         "astro-portabletext": "^0.9.6",
         "date-fns": "^3.3.1",
+        "slugify": "^1.6.6",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.3.3"
       },
@@ -11729,6 +11730,14 @@
         "react": ">=18.2.0",
         "react-dom": ">=18.2.0",
         "slate": ">=0.99.0"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "astro": "^4.4.9",
     "astro-portabletext": "^0.9.6",
     "date-fns": "^3.3.1",
+    "slugify": "^1.6.6",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"
   },

--- a/src/components/CustomHeading.astro
+++ b/src/components/CustomHeading.astro
@@ -1,0 +1,14 @@
+---
+import slugify from "slugify";
+
+const { node } = Astro.props;
+const slug = slugify(node.children[0].text, {
+  lower: true,
+  strict: true,
+  locale: "en",
+});
+const HeadingElement = node.style;
+---
+
+<a class="hidden" href={`#${slug}`} aria-hidden="true" tab-index={-1}>#</a>
+<HeadingElement id={slug}><slot /></HeadingElement>

--- a/src/components/PortableText.astro
+++ b/src/components/PortableText.astro
@@ -1,12 +1,18 @@
 ---
+import React from "react";
 import { PortableText as PortableTextInternal } from "astro-portabletext";
 import PortableTextImage from "./PortableTextImage.astro";
 import PortableTextCode from "./PortableTextCode.astro";
 import Separator from "./Separator.astro";
+import CustomHeading from "./CustomHeading.astro";
 
 const { portableText } = Astro.props;
 
 const components = {
+  block: {
+    h2: CustomHeading,
+    h3: CustomHeading,
+  },
   type: {
     image: PortableTextImage,
     code: PortableTextCode,


### PR DESCRIPTION
Adds a custom element for heading (h2, h3) elements in PortableText blocks. Slugifies the heading text and uses the slug for the anchor string. No Sanity type needed.