### PR TITLE
defined homeCard schema and added to Sanity interface

### DIFF
--- a/sanity/sanity.config.ts
+++ b/sanity/sanity.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
               S.documentTypeListItem('author'),
               S.documentTypeListItem('page'),
               S.documentTypeListItem('menu'),
+              S.documentTypeListItem('homeCard'),
           ])
       },
   }), visionTool(), codeInput()],

--- a/sanity/schemaTypes/homeCard.ts
+++ b/sanity/schemaTypes/homeCard.ts
@@ -1,0 +1,111 @@
+import {defineType} from 'sanity'
+
+export default defineType({
+  name: 'homeCard',
+  title: 'Home Cards',
+  type: 'document',
+  fields: [
+    {
+      name: 'order',
+      title: 'Order',
+      type: 'number',
+      validation: (rule) => rule.required().integer().positive(),
+    },
+    {
+      name: 'cardType',
+      title: 'Card Type',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'Hero', value: 'hero'},
+          {title: 'Story', value: 'story'},
+          {title: 'Feature', value: 'feature'},
+          {title: 'Footer', value: 'footer'},
+        ],
+      },
+      validation: (rule) => rule.required(),
+    },
+    {
+      name: 'headline',
+      title: 'Headline',
+      type: 'string',
+      validation: (rule) => rule.required(),
+    },
+    {
+      name: 'body',
+      title: 'Body',
+      type: 'text',
+      validation: (rule) => rule.required(),
+    },
+    {
+      name: 'bodyMinimized',
+      title: 'Body Minimized',
+      type: 'text',
+      description: 'A shorter version of the body text',
+    },
+    {
+      name: 'media',
+      title: 'Photo or Video',
+      type: 'object',
+      fields: [
+        {
+          name: 'type',
+          title: 'Media Type',
+          type: 'string',
+          options: {
+            list: [
+              {title: 'Photo', value: 'photo'},
+              {title: 'Video', value: 'video'},
+            ],
+          },
+          validation: (rule: any) => rule.required(),
+        },
+        {
+          name: 'photo',
+          title: 'Photo',
+          type: 'image',
+          hidden: ({parent}: any) => parent?.type !== 'photo',
+        },
+        {
+          name: 'video',
+          title: 'Video',
+          type: 'file',
+          hidden: ({parent}: any) => parent?.type !== 'video',
+        },
+      ],
+    },
+    {
+      name: 'button',
+      title: 'Button',
+      type: 'object',
+      fields: [
+        {
+          name: 'title',
+          title: 'Button Text',
+          type: 'string',
+        },
+        {
+          name: 'url',
+          title: 'Button URL',
+          type: 'url',
+          validation: (rule: any) => rule.uri({
+            scheme: ['http', 'https', 'mailto', 'tel']
+          })
+        },
+        {
+          name: 'openNewWindow',
+          title: 'Open in New Window',
+          type: 'boolean',
+          initialValue: false,
+        },
+      ],
+    },
+  ],
+  preview: {
+    select: {
+      title: 'headline',
+      subtitle: 'cardType',
+      media: 'media.photo',
+    },
+  },
+})

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -9,6 +9,7 @@ import post from './post'
 import globalContent from './globalContent';
 import postTag from './postTag'
 import separator from './separator'
+import homeCard from './homeCard'
 
 export const schemaTypes = [
   post,
@@ -21,5 +22,6 @@ export const schemaTypes = [
   blockLink,
   blockVideo,
   menu,
-  separator
+  separator,
+  homeCard,
 ]


### PR DESCRIPTION
This pull request introduces a new schema called `homeCard` and integrates it into the Sanity CMS interface. The `homeCard` schema will be used to manage content for the homepage cards on the website. Verified that the `homeCard` schema appears in the Sanity Studio interface. Ensured that new `homeCard` documents can be created, edited, and deleted within the Sanity Studio.