### PR TITLE
home: replace app download buttons with newsletter signup

### DIFF
--- a/src/components/HomeCards/HeroCard.tsx
+++ b/src/components/HomeCards/HeroCard.tsx
@@ -1,98 +1,78 @@
-import React from 'react';
-import BaseCard from './BaseCard';
-import ContentWrapper from './ContentWrapper';
-import { urlForImage } from '../../utils/urlForImage';
-import type { HomeCard } from '../../utils/types';
-import { FaApple, FaGooglePlay } from 'react-icons/fa';
+import React from "react";
+import BaseCard from "./BaseCard";
+import ContentWrapper from "./ContentWrapper";
+import { urlForImage } from "../../utils/urlForImage";
+import type { HomeCard } from "../../utils/types";
+import { FaApple, FaGooglePlay } from "react-icons/fa";
+import NewsletterSignup from "../NewsletterSignup";
 
 interface HeroCardProps extends HomeCard {
   isTopCard: boolean;
   index: number;
 }
 
-const HeroCard: React.FC<HeroCardProps> = (props) => {
-  const desktopImageUrl = props.media?.photo?.asset ? 
-    urlForImage(props.media.photo)
-      .url()
-      + '?v=1'
-    : '';
+const HeroCard: React.FC<HeroCardProps> = props => {
+  const desktopImageUrl = props.media?.photo?.asset
+    ? urlForImage(props.media.photo).url() + "?v=1"
+    : "";
 
-  const mobileImageUrl = props.media?.mobilePhoto?.asset ? 
-    urlForImage(props.media.mobilePhoto)
-      .url()
-      + '?v=1'
+  const mobileImageUrl = props.media?.mobilePhoto?.asset
+    ? urlForImage(props.media.mobilePhoto).url() + "?v=1"
     : desktopImageUrl; // Fallback to desktop image if no mobile image
 
   return (
     <BaseCard {...props}>
-      <div 
-        className="cta-card bg-[#fff] h-full relative overflow-hidden" 
-      >
+      <div className="cta-card relative h-full overflow-hidden bg-[#fff]">
         {/* Desktop Image */}
-        <div 
-          className="hidden md:block absolute inset-0" 
-          style={{ 
-            backgroundImage: `url(${desktopImageUrl})`, 
-            backgroundSize: 'contain',
-            backgroundPosition: 'bottom',
-            backgroundRepeat: 'no-repeat'
+        <div
+          className="absolute inset-0 hidden md:block"
+          style={{
+            backgroundImage: `url(${desktopImageUrl})`,
+            backgroundSize: "contain",
+            backgroundPosition: "bottom",
+            backgroundRepeat: "no-repeat",
           }}
         />
-        {/* Mobile Image */}
-
-        
-        <div className="flex h-full flex-col md:block p-6 md:p-12 relative">
-          <div className="mx-auto max-w-[600px] w-full flex flex-col flex-1 md:flex-none justify-center md:justify-start">
-            <h2 className="text-lg text-[#222] mb-4 font-medium tracking-tight text-center break-words">
+        <div className="relative flex h-full flex-col p-6 md:block md:p-12">
+          <div className="mx-auto flex w-full max-w-[600px] flex-1 flex-col justify-center md:flex-none md:justify-start">
+            <h2 className="mb-4 break-words text-center text-lg font-medium tracking-tight text-[#222]">
               {props.headline}
             </h2>
-            <h2 className="text-base text-neutral-400 mb-8 md:mb-12 font-normal tracking-tight text-center">
+            <h2 className="mb-4 text-center text-base font-normal tracking-tight text-neutral-400 md:mb-8">
               {props.body}
             </h2>
-            <div className="flex flex-row gap-2 md:gap-4 w-full justify-center">
-              <a
-                className="rounded-lg px-3 md:px-6 py-1.5 md:py-3 bg-[#E2E3E0] text-[#666] w-[140px] md:w-[200px] hover:bg-[#d6d7d4] transition-colors duration-300 flex items-center justify-center md:justify-start"
-                href="https://apps.apple.com/us/app/tlon-tlon-messenger/id6451392109"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <div className="w-5 md:w-6 flex justify-center">
-                  <FaApple className="text-lg md:text-2xl" />
-                </div>
-                <div className="ml-1.5 md:ml-4 md:flex-1 md:text-left">
-                  <span className="hidden md:block text-xs">Download on the</span>
-                  <span className="text-xs md:text-base font-semibold">
-                    <span className="md:hidden">App Store</span>
-                    <span className="hidden md:inline">App Store</span>
-                  </span>
-                </div>
-              </a>
-              <a
-                className="rounded-lg px-3 md:px-6 py-1.5 md:py-3 bg-[#E2E3E0] text-[#666] w-[140px] md:w-[200px] hover:bg-[#d6d7d4] transition-colors duration-300 flex items-center justify-center md:justify-start"
-                href="https://play.google.com/store/apps/details?id=io.tlon.groups"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <div className="w-5 md:w-6 flex justify-center">
-                  <FaGooglePlay className="text-lg md:text-2xl" />
-                </div>
-                <div className="ml-1.5 md:ml-4 md:flex-1 md:text-left">
-                  <span className="hidden md:block text-xs">Get it on</span>
-                  <span className="text-xs md:text-base font-semibold">
-                    <span className="md:hidden">Google Play</span>
-                    <span className="hidden md:inline">Google Play</span>
-                  </span>
-                </div>
-              </a>
+            <NewsletterSignup />
+            <div className="mt-8 flex flex-row justify-center gap-2 md:gap-4">
+              <p className="text-sm font-normal tracking-tight text-neutral-400">
+                Using Tlon already? Download for{" "}
+                <a
+                  className="underline"
+                  href="https://apps.apple.com/us/app/tlon-tlon-messenger/id6451392109"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  iOS
+                </a>{" "}
+                or{" "}
+                <a
+                  className="underline"
+                  href="https://play.google.com/store/apps/details?id=io.tlon.groups"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Android
+                </a>
+              </p>
             </div>
           </div>
-          <div 
-            className="w-full h-[50%] md:hidden mt-6" 
+          {/* Mobile Image */}
+          <div
+            className="mt-6 h-[50%] w-full md:hidden"
             style={{
-              backgroundImage: `url(${mobileImageUrl})`, 
-              backgroundSize: '80%',
-              backgroundPosition: '50% 50%',
-              backgroundRepeat: 'no-repeat'
+              backgroundImage: `url(${mobileImageUrl})`,
+              backgroundSize: "80%",
+              backgroundPosition: "50% 50%",
+              backgroundRepeat: "no-repeat",
             }}
           />
         </div>

--- a/src/components/HomeCards/HeroCard.tsx
+++ b/src/components/HomeCards/HeroCard.tsx
@@ -43,8 +43,8 @@ const HeroCard: React.FC<HeroCardProps> = props => {
             </h2>
             <NewsletterSignup />
             <div className="mt-8 flex flex-row justify-center gap-2 md:gap-4">
-              <p className="text-sm font-normal tracking-tight text-neutral-400">
-                Using Tlon already? Download for{" "}
+              <p className="text-center text-sm font-normal tracking-tight text-neutral-400">
+                Have an invite or account? Download for{" "}
                 <a
                   className="underline"
                   href="https://apps.apple.com/us/app/tlon-tlon-messenger/id6451392109"

--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -27,7 +27,7 @@ const NewsletterSignup: React.FC = () => {
           autoComplete="off"
           required
           className="block w-full text-ellipsis rounded-2xl border border-blackish/10 px-6 py-4 pr-36 shadow-lg transition-colors hover:border-blackish/30 focus:border-blackish/30 focus:outline-none"
-          placeholder="Sign up for early access"
+          placeholder="Sign up to join the waitlist"
         />
         <div className="absolute left-[-5000px]" aria-hidden="true">
           <input

--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+
+const NewsletterSignup: React.FC = () => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    const form = e.currentTarget;
+    const emailInput = form.elements.namedItem("EMAIL") as HTMLInputElement;
+
+    if (!emailInput.value || !emailInput.validity.valid) {
+      e.preventDefault();
+      return false;
+    }
+    return true;
+  };
+
+  return (
+    <div>
+      <form
+        action={import.meta.env.VITE_MAILCHIMP_SIGNUP}
+        method="post"
+        target="_self"
+        className="relative font-medium leading-none"
+        onSubmit={handleSubmit}
+      >
+        <input
+          type="email"
+          name="EMAIL"
+          autoComplete="off"
+          required
+          className="block w-full text-ellipsis rounded-2xl border border-blackish/10 px-6 py-4 pr-36 shadow-lg transition-colors hover:border-blackish/30 focus:border-blackish/30 focus:outline-none"
+          placeholder="Sign up for early access"
+        />
+        <div className="absolute left-[-5000px]" aria-hidden="true">
+          <input
+            type="text"
+            name="b_f9f52f752b920bad5e8b46282_5f71947001"
+            tabIndex={-1}
+            value=""
+          />
+        </div>
+        <button
+          type="submit"
+          className="absolute right-0 top-1/2 inline-block -translate-y-1/2 rounded-2xl p-4 text-mono-500 transition-colors hover:text-black dark:text-mono-600 dark:hover:text-mono-500"
+        >
+          Subscribe
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default NewsletterSignup;

--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -26,8 +26,8 @@ const NewsletterSignup: React.FC = () => {
           name="EMAIL"
           autoComplete="off"
           required
-          className="block w-full text-ellipsis rounded-2xl border border-blackish/10 px-6 py-4 pr-36 shadow-lg transition-colors hover:border-blackish/30 focus:border-blackish/30 focus:outline-none"
-          placeholder="Sign up to join the waitlist"
+          className="block w-full text-ellipsis rounded-2xl border border-blackish/10 px-6 py-4 pr-24 shadow-lg transition-colors hover:border-blackish/30 focus:border-blackish/30 focus:outline-none"
+          placeholder="Join the waitlist"
         />
         <div className="absolute left-[-5000px]" aria-hidden="true">
           <input
@@ -40,7 +40,7 @@ const NewsletterSignup: React.FC = () => {
         </div>
         <button
           type="submit"
-          className="absolute right-0 top-1/2 inline-block -translate-y-1/2 rounded-2xl p-4 text-mono-500 transition-colors hover:text-black dark:text-mono-600 dark:hover:text-mono-500"
+          className="absolute right-0 top-1/2 inline-block -translate-y-1/2 rounded-2xl bg-transparent p-4 text-mono-500 transition-colors hover:text-black dark:text-mono-600 dark:hover:text-mono-500"
         >
           Subscribe
         </button>

--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -34,7 +34,8 @@ const NewsletterSignup: React.FC = () => {
             type="text"
             name="b_f9f52f752b920bad5e8b46282_5f71947001"
             tabIndex={-1}
-            value=""
+            defaultValue=""
+            readOnly
           />
         </div>
         <button


### PR DESCRIPTION
Does what it says on the tin. Deprioritizes app downloads in favor of our old newsletter signup form.