### PR TITLE
site: add changelog section, document type

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,14 @@ module.exports = {
   },
   overrides: [
     {
+      files: ["*.ts", "*.tsx"],
+      parser: "@typescript-eslint/parser",
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    {
       files: ["*.astro"],
       parser: "astro-eslint-parser",
       parserOptions: {

--- a/sanity/sanity.config.ts
+++ b/sanity/sanity.config.ts
@@ -28,6 +28,7 @@ export default defineConfig([
                   .documentId('53c46b24-cf16-438f-9f9c-12537707112a'),
               ),
               S.documentTypeListItem('post'),
+              S.documentTypeListItem('changelog'),
               S.documentTypeListItem('author'),
               S.documentTypeListItem('page'),
               S.documentTypeListItem('menu'),

--- a/sanity/schemaTypes/changelog.ts
+++ b/sanity/schemaTypes/changelog.ts
@@ -1,0 +1,149 @@
+import {defineField, defineType} from 'sanity'
+import {ClockIcon} from '@sanity/icons'
+
+export default defineType({
+  name: 'changelog',
+  title: 'Changelog',
+  icon: ClockIcon,
+  type: 'document',
+  groups: [
+    {
+      name: 'content',
+      title: 'Content',
+      default: true,
+    },
+    {
+      name: 'release',
+      title: 'Release Info',
+    },
+  ],
+  fields: [
+    defineField({
+      name: 'app',
+      title: 'App Name',
+      type: 'string',
+      group: 'content',
+      validation: (rule) =>
+        rule.required().max(100).warning("The app name shouldn't be longer than 100 characters"),
+    }),
+    defineField({
+      name: 'version',
+      title: 'Version Number',
+      type: 'string',
+      description: 'e.g., v1.2.0, 2024.1, etc.',
+      group: 'release',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      description: 'Used in site url',
+      type: 'slug',
+      options: {
+        source: (doc: any) => {
+          const app = doc.app || '';
+          const version = doc.version || '';
+          return `${app} ${version}`.trim().toLowerCase().replace(/\s+/g, '-');
+        },
+        maxLength: 96,
+      },
+      group: 'content',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'releaseType',
+      title: 'Release Type',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'Major Release', value: 'major'},
+          {title: 'Minor Release', value: 'minor'},
+          {title: 'Patch', value: 'patch'},
+          {title: 'Hotfix', value: 'hotfix'},
+          {title: 'Beta', value: 'beta'},
+          {title: 'Security Update', value: 'security'},
+        ],
+      },
+      group: 'release',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'releaseDate',
+      title: 'Release Date',
+      type: 'date',
+      group: 'release',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'featuredImage',
+      title: 'Featured image',
+      type: 'blockImage',
+      group: 'content',
+      description: 'Optional image for the changelog entry',
+    }),
+    defineField({
+      name: 'summary',
+      title: 'Summary',
+      type: 'blockContent',
+      group: 'content',
+      description: 'Brief summary of the changes for listings',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'changes',
+      title: 'Detailed Changes',
+      type: 'blockContent',
+      group: 'content',
+      description: 'Detailed breakdown of all changes, improvements, and fixes',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'breakingChanges',
+      title: 'Breaking Changes',
+      type: 'blockContent',
+      group: 'content',
+      description: 'Important breaking changes that users need to be aware of',
+    }),
+    defineField({
+      name: 'migrationNotes',
+      title: 'Migration Notes',
+      type: 'blockContent',
+      group: 'content',
+      description: 'Instructions for users to migrate to this version',
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Release Date, New',
+      name: 'releaseDateDesc',
+      by: [
+        {field: 'releaseDate', direction: 'desc'},
+        {field: '_createdAt', direction: 'desc'}
+      ]
+    },
+    {
+      title: 'Release Date, Old',
+      name: 'releaseDateAsc',
+      by: [
+        {field: 'releaseDate', direction: 'asc'},
+        {field: '_createdAt', direction: 'asc'}
+      ]
+    },
+  ],
+  preview: {
+    select: {
+      app: 'app',
+      version: 'version',
+      releaseType: 'releaseType',
+      releaseDate: 'releaseDate',
+      media: 'featuredImage.imageRef',
+    },
+    prepare(selection) {
+      const {app, version, releaseType, releaseDate} = selection
+      return {
+        title: `${app} ${version}`,
+        subtitle: `${releaseType} • ${releaseDate}`
+      }
+    },
+  },
+}) 

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -3,6 +3,7 @@ import blockContent from './blockContent'
 import blockImage from './blockImage'
 import blockLink from './blockLink'
 import blockVideo from './blockVideo'
+import changelog from './changelog'
 import menu from './menu'
 import page from './page'
 import post from './post'
@@ -13,6 +14,7 @@ import homeCard from './homeCard'
 
 export const schemaTypes = [
   post,
+  changelog,
   postTag,
   author,
   page,

--- a/src/components/ChangelogExcerpt.astro
+++ b/src/components/ChangelogExcerpt.astro
@@ -1,0 +1,52 @@
+---
+import Picture from "./Picture.astro";
+import { PortableText as PortableTextInternal } from "astro-portabletext";
+
+import { type BlockImage } from "../utils/types";
+
+interface Props {
+  app: string;
+  version: string;
+  releaseType: string;
+  releaseDate: string;
+  summary: any;
+  featuredImage?: BlockImage;
+  slug: string;
+}
+
+const { app, version, releaseDate, summary, featuredImage, slug } = Astro.props;
+
+function formatDate(date: string) {
+  if (!date) return "TBD";
+  const d = new Date(date);
+  if (isNaN(d.getTime())) return "TBD";
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `~${year}.${month}.${day}`;
+}
+
+---
+
+<div>
+  <a class="mx-auto" href={`/changelog/${slug}`}>
+    <div class="mx-auto max-w-inner-xs items-center">
+      {featuredImage && (
+        <div class="mx-auto inline-block">
+          <div class="aspect-[16/9] rounded-2xl overflow-hidden">
+            <Picture asset={featuredImage} visualMaxWidth={1120} />
+          </div>
+        </div>
+      )}
+      <header class="flex items-center py-1">
+        <h2 class="inline-block text-lg font-medium tracking-tight">
+          {app} {version}
+          <span class="whitespace-nowrap opacity-40">{formatDate(releaseDate)}</span>
+        </h2>
+      </header>
+      <div class="prose prose-lg prose-tlon dark:prose-invert leading-normal text-[#666]">
+        <PortableTextInternal value={summary} />
+      </div>
+    </div>
+  </a>
+</div> 

--- a/src/components/ChangelogList.astro
+++ b/src/components/ChangelogList.astro
@@ -1,0 +1,31 @@
+---
+import ChangelogExcerpt from "./ChangelogExcerpt.astro";
+import { type ChangelogEntry } from "../utils/types";
+
+interface Props {
+  entries: ChangelogEntry[];
+}
+
+const { entries } = Astro.props;
+---
+{entries && entries.length > 0 ? (
+  <div class="space-y-24 pb-24">
+    {entries.map((entry: ChangelogEntry) => (
+      <ChangelogExcerpt
+        app={entry.app}
+        version={entry.version}
+        releaseType={entry.releaseType}
+        releaseDate={entry.releaseDate}
+        summary={entry.summary}
+        featuredImage={entry.featuredImage}
+        slug={entry.slug}
+      />
+    ))}
+  </div>
+) : (
+  <div class="text-center py-12">
+    <p class="text-gray-500 mb-4">
+      No changelog entries found yet.
+    </p>
+  </div>
+)} 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,6 @@
 import { getFooterNav } from "../utils/api";
 
 const links = await getFooterNav();
-const year = new Date().getFullYear();
 ---
 
 <footer role="contentinfo" class="space-y-3 py-32 text-center">
@@ -24,6 +23,11 @@ const year = new Date().getFullYear();
           <li>
             <a href="/posts" class="link-underline-hover inline-block">
               Posts
+            </a>
+          </li>
+          <li>
+            <a href="/changelog" class="link-underline-hover inline-block">
+              Changelog
             </a>
           </li>
         </ul>

--- a/src/pages/changelog/[slug].astro
+++ b/src/pages/changelog/[slug].astro
@@ -82,9 +82,9 @@ function formatDate(date: string) {
     >
       <PageTitle title={`${app} ${version}`} />
       <div class="pb-12 flex items-center gap-3">
-        <span class="text-lg text-gray-900">Released on {formatDate(releaseDate)}</span>
+        <span class="text-md">{formatDate(releaseDate)}</span>
         <span
-          class={`inline-flex items-center rounded-lg px-3 py-1 text-sm font-medium ${getReleaseTypeColor(releaseType)}`}
+          class={`inline-flex items-center rounded-lg px-2 py-1 text-xs font-medium ${getReleaseTypeColor(releaseType)}`}
         >
           {getReleaseTypeLabel(releaseType)}
         </span>

--- a/src/pages/changelog/[slug].astro
+++ b/src/pages/changelog/[slug].astro
@@ -1,0 +1,155 @@
+---
+import { getChangelogPaths } from "../../utils/api";
+import type { ChangelogEntry, BlockImage, AuthorObj } from "../../utils/types";
+
+import GlobalLayout from "../../layouts/GlobalLayout.astro";
+import PageTitle from "../../components/PageTitle.astro";
+import Picture from "../../components/Picture.astro";
+import PortableText from "../../components/PortableText.astro";
+
+interface Props extends ChangelogEntry {
+  relatedChangelog?: RelatedChangelogEntry[];
+}
+
+interface RelatedChangelogEntry {
+  title: string;
+  slug: string;
+  version: string;
+  releaseDate: string;
+  author: AuthorObj;
+  featuredImage?: BlockImage;
+}
+
+export async function getStaticPaths() {
+  return await getChangelogPaths();
+}
+
+const {
+  app,
+  version,
+  releaseType,
+  releaseDate,
+  featuredImage,
+  summary,
+  changes,
+  breakingChanges,
+  migrationNotes,
+} = Astro.props;
+
+function getReleaseTypeColor(type: string) {
+  const colors = {
+    major: "bg-red-100 text-red-800 border-red-200",
+    minor: "bg-blue-100 text-blue-800 border-blue-200",
+    patch: "bg-green-100 text-green-800 border-green-200",
+    hotfix: "bg-orange-100 text-orange-800 border-orange-200",
+    beta: "bg-purple-100 text-purple-800 border-purple-200",
+    security: "bg-yellow-100 text-yellow-800 border-yellow-200",
+  };
+  return (
+    colors[type as keyof typeof colors] ||
+    "bg-gray-100 text-gray-800 border-gray-200"
+  );
+}
+
+function getReleaseTypeLabel(type: string) {
+  const labels = {
+    major: "Major Release",
+    minor: "Minor Release",
+    patch: "Patch",
+    hotfix: "Hotfix",
+    beta: "Beta",
+    security: "Security Update",
+  };
+  return labels[type as keyof typeof labels] || type;
+}
+
+function formatDate(date: string) {
+  const d = new Date(date);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `~${year}.${month}.${day}`;
+}
+---
+
+<GlobalLayout
+  metaDescription={`${app} ${version} release notes and changelog`}
+  metaTitle={`${app} ${version}`}
+>
+  <article>
+    <header
+      class="mx-auto max-w-inner-xs space-y-4 font-medium tracking-tight md:max-w-inner-sm"
+    >
+      <PageTitle title={`${app} ${version}`} />
+      <div class="pb-12 flex items-center gap-3">
+        <span class="text-lg text-gray-900">Released on {formatDate(releaseDate)}</span>
+        <span
+          class={`inline-flex items-center rounded-lg px-3 py-1 text-sm font-medium ${getReleaseTypeColor(releaseType)}`}
+        >
+          {getReleaseTypeLabel(releaseType)}
+        </span>
+      </div>
+
+    </header>
+
+    {
+      featuredImage && (
+        <div class="mx-auto flex max-w-inner-lg items-center justify-center py-16">
+          <div class="aspect-[16/9] overflow-hidden rounded-2xl">
+            <Picture asset={featuredImage} visualMaxWidth={750} />
+          </div>
+        </div>
+      )
+    }
+
+    <div class="mx-auto max-w-inner-xs md:max-w-inner-sm">
+      {
+        summary && (
+          <section class="mb-12 prose prose-lg prose-tlon sm:prose-xl prose-headings:mt-2 prose-headings:pb-4 prose-headings:pt-4 prose-headings:text-md prose-headings:font-semibold prose-p:leading-8 prose-a:font-normal hover:prose-a:no-underline prose-blockquote:border-l-2 prose-blockquote:font-normal prose-li:my-1.5 prose-li:leading-7">
+            <h2>Summary</h2>
+            <PortableText portableText={summary} />
+          </section>
+        )
+      }
+
+      {
+        changes && (
+          <section class="mb-12 prose prose-lg prose-tlon sm:prose-xl prose-headings:mt-2 prose-headings:pb-4 prose-headings:pt-4 prose-headings:text-md prose-headings:font-semibold prose-p:leading-8 prose-a:font-normal hover:prose-a:no-underline prose-blockquote:border-l-2 prose-blockquote:font-normal prose-li:my-1.5 prose-li:leading-7">
+            <h2>What's Changed</h2>
+            <PortableText portableText={changes} />
+          </section>
+        )
+      }
+
+      {
+        breakingChanges && (
+          <section class="mb-12 prose prose-lg prose-tlon mb-12 sm:prose-xl prose-headings:mt-2 prose-headings:pb-4 prose-headings:pt-4 prose-headings:text-md prose-headings:font-semibold prose-p:leading-8 prose-a:font-normal hover:prose-a:no-underline prose-blockquote:border-l-2 prose-blockquote:font-normal prose-li:my-1.5 prose-li:leading-7">
+            <h3>Breaking Changes</h3>
+            <PortableText portableText={breakingChanges} />
+          </section>
+        )
+      }
+
+      {
+        migrationNotes && (
+          <section class="mb-12 prose prose-lg prose-tlon sm:prose-xl prose-headings:mt-2 prose-headings:pb-4 prose-headings:pt-4 prose-headings:text-md prose-headings:font-semibold prose-p:leading-8 prose-a:font-normal hover:prose-a:no-underline prose-blockquote:border-l-2 prose-blockquote:font-normal prose-li:my-1.5 prose-li:leading-7">
+            <h3>Migration Guide</h3>
+            <PortableText portableText={migrationNotes} />
+          </section>
+        )
+      }
+    </div>
+
+    <div class="mx-auto max-w-inner-xs pt-16 md:max-w-inner-sm">
+      <div class="text-center">
+        <a
+          href="/changelog"
+          class="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-gray-700 transition-colors
+          max-sm:hover:underline hover:sm:bg-navHover"
+        >
+          ← Back to Changelog
+        </a>
+      </div>
+    </div>
+  </article>
+</GlobalLayout>

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -1,0 +1,23 @@
+---
+import { getChangelog } from "../../utils/api";
+
+import GlobalLayout from "../../layouts/GlobalLayout.astro";
+import NewsletterSignup from "../../components/NewsletterSignup.tsx";
+import PageTitle from "../../components/PageTitle.astro";
+import ChangelogList from "../../components/ChangelogList.astro";
+
+const changelogEntries = await getChangelog();
+---
+
+<GlobalLayout
+  metaTitle="Changelog - Release Notes & Updates"
+  metaDescription="Stay up to date with the latest features, improvements, and fixes. View our complete changelog and release history."
+>
+  <div class="mx-auto max-w-inner-xs space-y-16 pb-36 pt-24 sm:pb-36">
+    <header>
+      <PageTitle title="Changelog" />
+    </header>
+    <ChangelogList entries={changelogEntries} />
+    <NewsletterSignup client:load />
+  </div>
+</GlobalLayout>

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -15,7 +15,10 @@ const changelogEntries = await getChangelog();
 >
   <div class="mx-auto max-w-inner-xs space-y-16 pb-36 pt-24 sm:pb-36">
     <header>
-      <PageTitle title="Changelog" />
+      <PageTitle
+        title="Changelog"
+        titleAlignment="left"
+      />
     </header>
     <ChangelogList entries={changelogEntries} />
     <NewsletterSignup client:load />

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -218,8 +218,42 @@ export async function getVideoGallery(id: string) {
       }
     }
   }`;
-  
+
   return sanityClient.fetch(query, { id });
+}
+
+// Get all changelog entries for listing
+export async function getChangelog() {
+  const query = `*[_type == "changelog"] | order(releaseDate desc) {
+    "slug": slug.current,
+    app,
+    version,
+    releaseType,
+    releaseDate,
+    "featuredImage": featuredImage.imageRef ${imageRefObj},
+    summary,
+    changes,
+    breakingChanges,
+    migrationNotes,
+  }`;
+  return await sanityClient.fetch(query);
+}
+
+// Get changelog entries for static path generation
+export async function getChangelogPaths() {
+  const query = `*[_type == "changelog"] | order(releaseDate desc) {
+    slug,
+    app,
+    version,
+    releaseType,
+    releaseDate,
+    "featuredImage": featuredImage.imageRef ${imageRefObj},
+    summary,
+    changes,
+    breakingChanges,
+    migrationNotes,
+  }`;
+  return paramMap(await sanityClient.fetch(query));
 }
 
 function paramMap(items: any) {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,3 @@
-// blockImage Sanity schema
-
 // author Sanity schema
 export interface AuthorObj {
   label: string;
@@ -19,6 +17,20 @@ export interface BlockVideo {
   width: number;
   height: number;
   poster: string;
+}
+
+// Changelog Sanity schema
+export interface ChangelogEntry {
+  slug: string;
+  app: string;
+  version: string;
+  releaseType: "major" | "minor" | "patch" | "hotfix" | "beta" | "security";
+  releaseDate: string;
+  featuredImage?: BlockImage;
+  summary: any;
+  changes: any;
+  breakingChanges?: any;
+  migrationNotes?: any;
 }
 
 // HomeCard Sanity schema


### PR DESCRIPTION
Adds a "Changelog" item in Sanity and handles display in Astro.

Changelog entries have:
- An app name ('%groups', 'Native apps', 'iOS app', etc)
- Version
- Slug (URL)
- Release date
- Release type ('major', 'minor', 'patch', etc)
- Optional image
- Summary
- Detailed changes
- Optional breaking changes
- Optional migration guide

Here's how it looks in Sanity:

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/1765f982-3174-4849-8878-75e778ead918" />

And on the site:

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/b064f0b2-2d75-4b05-960c-bdfee0f045d1" />


<img width="1582" alt="image" src="https://github.com/user-attachments/assets/134cbc3a-63d5-46bd-8f21-575966992beb" />
